### PR TITLE
fix: skopeo issues with /etc/containers/registries.conf

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,6 +83,10 @@ jobs:
       - name: Build
         run: nix build -L ".#${VARIANT}"
 
+      - name: Update /etc/containers/registries.conf
+        run: |
+          echo 'unqualified-search-registries = ["docker.io", "quay.io"]' | sudo tee /etc/containers/registries.conf
+
       - name: Login
         if: |
           github.ref_name == 'main' ||
@@ -133,6 +137,10 @@ jobs:
 
       # see https://github.com/actions/runner-images/issues/10443
       - run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
+      - name: Update /etc/containers/registries.conf
+        run: |
+          echo 'unqualified-search-registries = ["docker.io", "quay.io"]' | sudo tee /etc/containers/registries.conf
 
       - name: Login
         env:


### PR DESCRIPTION
Replace `/etc/containers/registries.conf` with v2-compatible content.

Error:
```
time="2026-06-03T15:34:27Z" level=fatal msg="get credentials: loading registries configuration \"/etc/containers/registries.conf\": registries.conf must be in v2 format but is in v1"
```

- https://github.com/podman-container-tools/skopeo/releases/tag/v1.23.0
- https://github.com/containers/image/blob/v5.36.0/docs/containers-registries.conf.5.md